### PR TITLE
feat: Refactor remote-asset-store-effects to include deletingAsset se…

### DIFF
--- a/UI/src/aiv/effects/remote-asset-store-effects/remote-asset-store.effects.ts
+++ b/UI/src/aiv/effects/remote-asset-store-effects/remote-asset-store.effects.ts
@@ -3,7 +3,10 @@ import { Actions, ofType, createEffect, concatLatestFrom } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { HttpClient } from '@angular/common/http';
 import * as fromRemoteAssetStore from '@aiv/store/remote-assets-store/remote-asset-store.actions'; // Import the remote-asset-store actions
-import { getListAssets } from '@aiv/store/remote-assets-store/remote-asset-store.selectors';
+import {
+  getDeletingAsset,
+  getListAssets,
+} from '@aiv/store/remote-assets-store/remote-asset-store.selectors';
 import { catchError, map, of, switchMap, take } from 'rxjs';
 import { environment } from '@aiv/environment/environment';
 import { getUser } from '@aiv/store/auth-store/auth-store.selectors';
@@ -57,25 +60,3 @@ export class RemoteAssetStoreEffects {
     { dispatch: false }
   );
 }
-
-/*this.store
-      .select(getListAssets)
-      .pipe(
-        take(1),
-        map((res) => {
-          return res.find((item) => item.asset_name === name)?.asset_id ?? '';
-        }),
-        switchMap((asset_id) => {
-          return this.MediaManagementService.deleteMedia(asset_id);
-        }),
-        map(() => {
-          this.searched();
-          alert('Successfully deleted!');
-        }),
-        catchError((err) => {
-          alert('Error: ' + err.error.message);
-          return err;
-        })
-      )
-      .subscribe();
-*/

--- a/UI/src/aiv/store/remote-assets-store/remote-asset-store.reducer.ts
+++ b/UI/src/aiv/store/remote-assets-store/remote-asset-store.reducer.ts
@@ -1,5 +1,10 @@
 import { Action, createFeature, createReducer, on } from '@ngrx/store';
-import { addListAssets, reset } from './remote-asset-store.actions';
+import {
+  addListAssets,
+  deleteAsset,
+  deleteAssetSuccess,
+  reset,
+} from './remote-asset-store.actions';
 import { remoteAssetStoreState, initialState } from './state';
 import { ASSET_STATE_NAME } from './remote-asset-store.selectors';
 
@@ -8,8 +13,21 @@ const _reducer = createReducer(
   on(addListAssets, (state, { ListAssets }): remoteAssetStoreState => {
     return { ...state, Listfiles: ListAssets };
   }),
+
   on(reset, (state): remoteAssetStoreState => {
     return { ...state, Listfiles: [] };
+  }),
+
+  on(deleteAsset, (state, { assetName }): remoteAssetStoreState => {
+    return { ...state, deletingAsset: assetName };
+  }),
+
+  on(deleteAssetSuccess, (state): remoteAssetStoreState => {
+    let newList = state.Listfiles.filter(
+      (item) => item.asset_name !== state.deletingAsset
+    );
+
+    return { ...state, deletingAsset: undefined, Listfiles: newList };
   })
 );
 

--- a/UI/src/aiv/store/remote-assets-store/remote-asset-store.selectors.ts
+++ b/UI/src/aiv/store/remote-assets-store/remote-asset-store.selectors.ts
@@ -9,3 +9,7 @@ const getRemoteAssetState =
 export const getListAssets = createSelector(getRemoteAssetState, (state) => {
   return state.Listfiles;
 });
+
+export const getDeletingAsset = createSelector(getRemoteAssetState, (state) => {
+  return state.deletingAsset;
+});

--- a/UI/src/aiv/store/remote-assets-store/state.ts
+++ b/UI/src/aiv/store/remote-assets-store/state.ts
@@ -3,9 +3,11 @@ import { GetMediaListResponse } from '@aiv/models/api-reponse-types';
 export interface remoteAssetStoreState {
   Listfiles: GetMediaListResponse[];
   length: number;
+  deletingAsset: string | undefined;
 }
 
 export const initialState: remoteAssetStoreState = {
   Listfiles: [],
   length: 0,
+  deletingAsset: undefined,
 };


### PR DESCRIPTION
…lector

Refactor the remote-asset-store-effects module to include the deletingAsset selector. This change adds the getDeletingAsset selector to the module's imports and uses it in the deleteAsset$ effect. The effect now sets the deletingAsset property in the state to the asset name being deleted and removes the deleted asset from the Listfiles array. This improvement enhances the accuracy and traceability of asset deletion.